### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,10 @@ caption-switcher/
 │   ├── 32x32.ico                 # Small icon (taskbar, title bar)
 │   └── 64x64.ico                 # Large icon (Alt+Tab, taskbar)
 ├── .github/
-│   └── copilot-instructions.md  # This file
+│   ├── copilot-instructions.md  # This file
+│   └── workflows/
+│       └── release.yaml         # Automated release via reusable workflow
+├── .gitignore                    # Ignores IDE artifacts and build outputs
 ├── CHANGELOG.md                  # Project changelog (Keep a Changelog format)
 ├── Clear.bat                     # Build artifact cleanup script
 ├── CONTRIBUTING.md               # Historical build information
@@ -72,7 +75,9 @@ There is **no automated build system** (no `Makefile`, no CI/CD). Building is do
 
 ## CI/CD Pipeline
 
-**None.** There are no GitHub Actions workflows or any other CI/CD pipelines configured for this repository.
+A single GitHub Actions workflow exists:
+
+- **`.github/workflows/release.yaml`** — triggers on push to `main`, calls a reusable workflow from `rios0rios0/pipelines` to create releases automatically.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to document the `release.yaml` workflow and add missing files to the repository structure tree
+
 ## [1.0.1] - 2026-04-28
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.