### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,6 +99,7 @@ All application logic resides in `CS.dpr` (~250 lines of procedural Object Pasca
 |-----------------------|---------------------------------------------------------------------|
 | `WindowProc()`        | Main message loop handler (`WM_COMMAND`, `WM_CTLCOLOR*`, `WM_DESTROY`) |
 | `EnumWindowsProc()`   | `EnumWindows` callback; filters visible top-level windows           |
+| `CreateMyClass()`     | Registers the window class via `RegisterClassA`                     |
 | `CreateMyForm()`      | Creates the main window with layered transparency                   |
 | `CreateMyComponent()` | Generic factory for Win32 controls (buttons, listbox, edits, labels) |
 | `CreateMyFont()`      | Creates a Times New Roman font (size 14)                            |
@@ -110,7 +111,7 @@ All application logic resides in `CS.dpr` (~250 lines of procedural Object Pasca
 
 `EnumWindowsProc` applies three criteria:
 1. `IsWindowVisible(Wnd)` — only visible windows
-2. `GetWindowLong(Wnd, GWL_HWNDPARENT) = 0` — only top-level windows
+2. `GetWindowLong(Wnd, GWL_HWNDPARENT) = 0` or parent is the desktop — only top-level windows
 3. `(GetWindowLong(Wnd, GWL_EXSTYLE) and WS_EX_TOOLWINDOW) = 0` — excludes toolwindows
 
 ### Custom Dark Theme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to add missing `CreateMyClass()` procedure and fix incomplete `EnumWindowsProc` filter description
+
 ## [1.0.2] - 2026-05-08
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.